### PR TITLE
Drop extension on reinstall to avoid potential failures

### DIFF
--- a/src/models/m_wikiconcept.erl
+++ b/src/models/m_wikiconcept.erl
@@ -816,7 +816,8 @@ install(Context) ->
         false ->
             ok
     end,
-    [] = z_db:q("create extension if not exists pg_trgm with schema public", Context),
+    [] = z_db:q("drop extension if exists pg_trgm", Context),
+    [] = z_db:q("create extension pg_trgm with schema public", Context),
     [] = z_db:q("
         create table wikiconcept (
             id serial not null,


### PR DESCRIPTION
For reference: I'm not 100% sure, but this should solve [this error happening on a deployment](https://grafana.stats.driebit.net/explore?schemaVersion=1&panes=%7B%229o2%22:%7B%22datasource%22:%22qb9jcFwVk%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapplication%3D%5C%22zotonic%5C%22,%20site%3D%5C%22oramsterdam%5C%22,%20environment%3D%5C%22acceptance%5C%22%7D%20%7C%3D%20%60public.gin_trgm_ops%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22qb9jcFwVk%22%7D,%22editorMode%22:%22builder%22,%22direction%22:%22backward%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1):
```
...
"reason":"{function_clause,
    [{z_module_manager,datamodel_manage,
         [mod_wikiconcept,
          {rollback,
              {{error,
                   {error,error,<<\"42704\">>,undefined_object,
                       <<\"operator class \\\"public.gin_trgm_ops\\\" does not exist for access method \\\"gin\\\"\">>,
                       [{file,<<\"indexcmds.c\">>},
                        {line,<<\"1831\">>},
                        {routine,<<\"ResolveOpClass\">>},
                        {severity,<<\"ERROR\">>}]}},
...
```