### PR TITLE
Revert pg_trgm extension creation logic

### DIFF
--- a/src/models/m_wikiconcept.erl
+++ b/src/models/m_wikiconcept.erl
@@ -816,8 +816,9 @@ install(Context) ->
         false ->
             ok
     end,
-    [] = z_db:q("drop extension if exists pg_trgm", Context),
-    [] = z_db:q("create extension pg_trgm with schema public", Context),
+    % The pg_trgm extension can only created once per database, so we
+    % create it in the public schema and the refer to that schema.
+    [] = z_db:q("create extension if not exists pg_trgm with schema public", Context),
     [] = z_db:q("
         create table wikiconcept (
             id serial not null,


### PR DESCRIPTION
Modify the creation of the pg_trgm extension to avoid errors if it already exists.

Better not drop the extension, as that might conflict with existing use of the extension in other places than wikiconcept.